### PR TITLE
修复僵尸末日中当玩家死亡时剩余玩家消息数量不对的问题

### DIFF
--- a/datapacks/zombiepve/data/minecraft/function/zombieever/died.mcfunction
+++ b/datapacks/zombiepve/data/minecraft/function/zombieever/died.mcfunction
@@ -11,9 +11,9 @@ execute if score zombie.mode board matches 2 run title @s subtitle ["\u00a7e如�
 execute if score zombie.mode board matches 3 run title @s subtitle ["\u00a7d由于模式设置，您已无法复活"]
 
 scoreboard players set tmp.count tick 0
+execute if score zombie.mode board matches 1 run function zombieever/fuhuo
+execute if score zombie.mode board matches 2.. run gamemode spectator @s
 execute as @a[team=play.zombie,gamemode=adventure] run scoreboard players add tmp.count tick 1
 execute if score zombie.mode board matches 2.. run title @a[team=play.zombie] actionbar [{"selector":"@s"}," \u00a7c死了，剩余玩家数量：",{"score":{"name": "tmp.count","objective": "tick"},"color":"gold"}]
 tp @s 630 40 -78 90 0
-execute if score zombie.mode board matches 1 run function zombieever/fuhuo
-execute if score zombie.mode board matches 2.. run gamemode spectator @s
 


### PR DESCRIPTION
https://github.com/FallenCrystal/Minecraft-Minigames-Map/commit/23f62315b0e0d2ea31ecab2ad2b53ad6facb0f63 修复的问题已在 https://github.com/wifi-left/Map-MiniGames/commit/ba33e7fda38d8150e29400c9496c33e7bc5c5beb 中被~~偷偷地~~被修复了.

此外,  还有几个小问题还未解决:
- 地牢中的牛奶 "第二杯半价" 是否应该同出生点上方的商店一样是 "空桶半价"? 因为它们的行为貌似是相同的.
- 1000心的boss被高级魔法棒直接干到只剩70了 ~~勇者真的很多余诶~~
![b0a7f5fc7c7d8b20d72834a73e1c0db3](https://github.com/user-attachments/assets/09eb5faf-88e2-4ca9-9d12-18d85196555c)
- 经验等级的最大值是201. 如果我认为没错的话, 应该是一个200的限制?
- 钱袋在整个游戏中只有一次是因为任务而发放的. 这样做是有什么原因吗?


单纯问一下:
- 您最近更新了1.21.5支持. 但我仍然会使用1.21.4相当长一段时间. 对没有那么老的旧版本支持有什么看法? 不会更新还是说接受pr?
- 您在 [主页](https://wifi-left.github.io/MC-MiniGames) 上额外提供了版权声明, 但您的项目使用了 CC0 1.0 Universal 许可证. 您知道这件事吗? 还是说您只是希望其他人能这么做? ~~当然, 也可以偷偷换掉~~